### PR TITLE
bugfix. Added logic to maximize Firefox with '--start-maximized' flag.

### DIFF
--- a/tass/core/drivers/browserdriver.py
+++ b/tass/core/drivers/browserdriver.py
@@ -63,6 +63,8 @@ class FirefoxDriver(webdriver.Firefox, WebDriverWaitWrapper):
         super().__init__(self, service=FirefoxService(
             GeckoDriverManager().install()),
             options=self._config_options(webdriver.FirefoxOptions, config))
+        if ('--start-maximized' in config.get('options', [])):
+            self.maximize_window()
 
 
 class EdgeDriver(webdriver.Edge, WebDriverWaitWrapper):


### PR DESCRIPTION
Use `webdriver.maximize_window()` to maximize firefox when the `--start-maximized` flag is passed as part of browser configurations.