### PR TITLE
Bugfix 34 default browser configurations not being read

### DIFF
--- a/tass/core/tass_files.py
+++ b/tass/core/tass_files.py
@@ -48,8 +48,8 @@ class TassRun(TassFile):
         for case in self._raw_test_cases:
             with open('tass/config/browsers.json') as f:
                 driver = {'browser': browser,
-                        'config': json.load(f)
-                        .get(self._browser_name, {})}
+                          'config': json.load(f)
+                          .get(self._browser_name, {})}
             tasscase = TassCase(parent=self, browser_config=driver, **case)
             yield tasscase
             self._completed_cases.append(tasscase)

--- a/tass/core/tass_files.py
+++ b/tass/core/tass_files.py
@@ -46,9 +46,10 @@ class TassRun(TassFile):
             raise ke
 
         for case in self._raw_test_cases:
-            driver = {'browser': browser,
-                      'config': json.load(open('tass/config/browsers.json'))
-                      .get(browser, {})}
+            with open('tass/config/browsers.json') as f:
+                driver = {'browser': browser,
+                        'config': json.load(f)
+                        .get(self._browser_name, {})}
             tasscase = TassCase(parent=self, browser_config=driver, **case)
             yield tasscase
             self._completed_cases.append(tasscase)

--- a/tass/drivers/browserdriver.py
+++ b/tass/drivers/browserdriver.py
@@ -13,6 +13,10 @@ def newDriver(browser, config):
 
 
 class WebDriverWaitWrapper():
+    @property
+    def browser(self):
+        self.capabilities['browserName']
+
     """ Wrapper class for adding general features to browser driver classes."""
     def wait_until(self, until_func, **kwargs):
         """ Wait for element to meet condition before returning the WebElement

--- a/tass/drivers/browserdriver.py
+++ b/tass/drivers/browserdriver.py
@@ -38,10 +38,6 @@ class WebDriverWaitWrapper():
         wait = WebDriverWait(self, self._config.get('explicit_wait', 10))
         return wait.until(until_func(**kwargs))
 
-    @property
-    def browser(self):
-        self.capabilities['browserName']
-
     def _config_options(self, browser_options, config):
         options_obj = browser_options()
         for opt in config.get('options', []):

--- a/tass/drivers/browserdriver.py
+++ b/tass/drivers/browserdriver.py
@@ -13,10 +13,6 @@ def newDriver(browser, config):
 
 
 class WebDriverWaitWrapper():
-    @property
-    def browser(self):
-        self.capabilities['browserName']
-
     """ Wrapper class for adding general features to browser driver classes."""
     def wait_until(self, until_func, **kwargs):
         """ Wait for element to meet condition before returning the WebElement
@@ -41,6 +37,10 @@ class WebDriverWaitWrapper():
         """
         wait = WebDriverWait(self, self._config.get('explicit_wait', 10))
         return wait.until(until_func(**kwargs))
+
+    @property
+    def browser(self):
+        self.capabilities['browserName']
 
     def _config_options(self, browser_options, config):
         options_obj = browser_options()

--- a/tests/actions/test_selenium.py
+++ b/tests/actions/test_selenium.py
@@ -32,7 +32,7 @@ class TestSelenium(unittest.TestCase):
         url = "https://www.google.ca"
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 selenium.load_url(driver, url)
                 self.assertEqual(driver.title, "Google")
                 driver.quit()
@@ -40,7 +40,7 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumLoadFile(self):
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 selenium.load_file(driver, self.test_page_url)
                 self.assertEqual(driver.title, "Page One")
                 driver.quit()
@@ -49,7 +49,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 selenium.click(driver,
                                locator={"by": "id", "value": "btnColor"})
@@ -63,7 +63,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 text = 'Selenium Test Type'
                 selenium.type(
@@ -79,7 +79,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 text = 'Selenium Test Type'
                 driver.find_element('id', 'nameField').send_keys(text)
@@ -100,7 +100,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 self.assertEqual(selenium.read_attribute(
                         driver, attribute='name',
@@ -111,7 +111,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 self.assertEqual(selenium.read_css(
                         driver, attribute='width',
@@ -122,7 +122,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_displayed(
@@ -136,7 +136,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 with self.assertRaises(TassHardAssertionError):
                     selenium.assert_displayed(
@@ -149,7 +149,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_displayed(
@@ -163,7 +163,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 with self.assertRaises(TassSoftAssertionError):
                     selenium.assert_displayed(
@@ -176,7 +176,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_not_displayed(
@@ -190,7 +190,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 with self.assertRaises(TassHardAssertionError):
                     selenium.assert_not_displayed(
@@ -203,7 +203,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_not_displayed(
@@ -217,7 +217,7 @@ class TestSelenium(unittest.TestCase):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
             driver = browser(self.config)
-            with self.subTest(browser=driver.browser):
+            with self.subTest(browser=driver.toJson()):
                 driver.get('file://' + url)
                 with self.assertRaises(TassSoftAssertionError):
                     selenium.assert_not_displayed(

--- a/tests/actions/test_selenium.py
+++ b/tests/actions/test_selenium.py
@@ -31,16 +31,16 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumLoadURL(self):
         url = "https://www.google.ca"
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 selenium.load_url(driver, url)
                 self.assertEqual(driver.title, "Google")
                 driver.quit()
 
     def test_SeleniumLoadFile(self):
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 selenium.load_file(driver, self.test_page_url)
                 self.assertEqual(driver.title, "Page One")
                 driver.quit()
@@ -48,8 +48,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumClick(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 selenium.click(driver,
                                locator={"by": "id", "value": "btnColor"})
@@ -62,8 +62,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumType(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 text = 'Selenium Test Type'
                 selenium.type(
@@ -78,8 +78,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumClear(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 text = 'Selenium Test Type'
                 driver.find_element('id', 'nameField').send_keys(text)
@@ -99,8 +99,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumReadAttribute(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 self.assertEqual(selenium.read_attribute(
                         driver, attribute='name',
@@ -110,8 +110,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumReadCSS(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 self.assertEqual(selenium.read_css(
                         driver, attribute='width',
@@ -121,8 +121,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertDisplayedSuccess(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_displayed(
@@ -135,8 +135,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertDisplayedFailed(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 with self.assertRaises(TassHardAssertionError):
                     selenium.assert_displayed(
@@ -148,8 +148,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertDisplayedSoftSuccess(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_displayed(
@@ -162,8 +162,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertDisplayedSoftFailed(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 with self.assertRaises(TassSoftAssertionError):
                     selenium.assert_displayed(
@@ -175,8 +175,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertNotDisplayedSuccess(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_not_displayed(
@@ -189,8 +189,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertNotDisplayedFailed(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 with self.assertRaises(TassHardAssertionError):
                     selenium.assert_not_displayed(
@@ -202,8 +202,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertNotDisplayedSoftSuccess(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 try:
                     selenium.assert_not_displayed(
@@ -216,8 +216,8 @@ class TestSelenium(unittest.TestCase):
     def test_SeleniumAssertNotDisplayedSoftFailed(self):
         url = os.path.join(pathlib.Path().resolve(), self.test_page_url)
         for browser in self.drivers:
-            with self.subTest(browser=browser.browser):
-                driver = browser(self.config)
+            driver = browser(self.config)
+            with self.subTest(browser=driver.browser):
                 driver.get('file://' + url)
                 with self.assertRaises(TassSoftAssertionError):
                     selenium.assert_not_displayed(


### PR DESCRIPTION
Fixed incorrect reference to an attribute. Default configurations are now read from file correctly.