### PR TITLE
Sorted unit tests into more focused classes.

### DIFF
--- a/tass-core/src/tass/core/actions/selenium.py
+++ b/tass-core/src/tass/core/actions/selenium.py
@@ -204,7 +204,6 @@ def select_dropdown(driver, value, using, find=_find_element, **kwargs):
         case _:
             raise ValueError(f'Select method {using} is not a valid method.')
 
-    
     try:
         dropdown = Select(find(driver, **kwargs))
         select(dropdown, value)

--- a/tass-core/tests/actions/test_selenium.py
+++ b/tass-core/tests/actions/test_selenium.py
@@ -180,7 +180,7 @@ class TestSeleniumStartupActions(TestSelenium):
                 finally:
                     PageReader.reset()
 
-    
+
 class TestSeleniumBasicActions(TestSelenium):
 
     def test_SeleniumClose(self):
@@ -473,7 +473,8 @@ class TestSeleniumWindowControlActions(TestSelenium):
                 driver.quit()
         finally:
             PageReader.reset()
-            
+
+
 class TestSeleniumDropdownActions(TestSelenium):
 
     def test_SeleniumSelectDropdownByText(self):
@@ -518,7 +519,7 @@ class TestSeleniumDropdownActions(TestSelenium):
                 self.assertEqual(sel.first_selected_option.text, 'AA')
                 driver.quit()
 
-            
+
 class TestSeleniumAssertActions(TestSelenium):
 
     def test_SeleniumAssertTextDisplayedSuccess(self):
@@ -1055,7 +1056,7 @@ class TestSeleniumAssertActions(TestSelenium):
                         exact=True)
                 driver.quit()
 
-            
+
 class SeleniumScreenshotActions(TestSelenium):
 
     def test_SeleniumScreenshotPage(self):


### PR DESCRIPTION
By using the new class names and the "unittest -k" keyword argument only specific unit tests will be run to reduce the time it takes to test blocks of changed code.